### PR TITLE
Improvements to Clusterly UI

### DIFF
--- a/trendly/src/app/add-cluster-dialog/add-cluster-dialog.component.html
+++ b/trendly/src/app/add-cluster-dialog/add-cluster-dialog.component.html
@@ -18,6 +18,6 @@
   <div class="btn">
     <button class="apply-button"
             [disabled]="!titleFormControl.valid"
-            (click)="data.addCluster(clusterTitle, data.clusterly)">Apply</button>
+            (click)="data.addCluster(clusterTitle, data.clusterly, data.query)">Apply</button>
   </div>
 </div>

--- a/trendly/src/app/add-cluster-dialog/add-cluster-dialog.component.ts
+++ b/trendly/src/app/add-cluster-dialog/add-cluster-dialog.component.ts
@@ -5,6 +5,7 @@ import {ErrorStateMatcher} from '@angular/material/core';
 import {MAT_DIALOG_DATA} from '@angular/material/dialog';
 
 import {ClustersSectionComponent} from '../clusters-section/clusters-section.component';
+import {CircleDatum} from '../models/circle-datum';
 
 /** Error when invalid control is dirty, touched, or submitted. */
 export class AddClusterErrorStateMatcher implements ErrorStateMatcher {
@@ -18,8 +19,11 @@ export class AddClusterErrorStateMatcher implements ErrorStateMatcher {
 }
 
 export interface AddClusterDialogData {
-  addCluster: (title: String, clusterly: ClustersSectionComponent) => void;
+  addCluster:
+      (title: String, clusterly: ClustersSectionComponent,
+       query: CircleDatum) => void;
   clustersTitles: String[];
+  query?: CircleDatum;
   clusterly: ClustersSectionComponent;
 }
 

--- a/trendly/src/app/app.module.ts
+++ b/trendly/src/app/app.module.ts
@@ -34,6 +34,7 @@ import {QueriesDialogComponent} from './queries-dialog/queries-dialog.component'
 import {TermInputComponent} from './term-input/term-input.component';
 import {TermsChipsInputComponent} from './terms-chips-input/terms-chips-input.component';
 import {TopBarComponent} from './top-bar/top-bar.component';
+import { MergeDialogComponent } from './merge-dialog/merge-dialog.component';
 
 
 @NgModule({
@@ -58,6 +59,7 @@ import {TopBarComponent} from './top-bar/top-bar.component';
     CategoryInputComponent,
     DeleteConfirmationDialogComponent,
     AddSimilarDialogComponent,
+    MergeDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/trendly/src/app/clusterly/clusterly.component.css
+++ b/trendly/src/app/clusterly/clusterly.component.css
@@ -63,3 +63,26 @@ table {
   font-family: 'Amatic SC', cursive;
   font-size: 25px;
 }
+
+#chart-container {
+  display: flex;
+  flex-flow: column wrap;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  align-items: center;
+  padding-left: 30px;
+}
+
+google-chart {
+  padding: 20px;
+  border: 4px solid #808080;
+  border-radius: 25px;
+}
+
+.headline {
+  padding: 20px;
+  font-size: 40px;
+  font-family: 'Amatic SC', cursive;
+  text-align: center;
+}

--- a/trendly/src/app/clusterly/clusterly.component.html
+++ b/trendly/src/app/clusterly/clusterly.component.html
@@ -55,9 +55,34 @@
             *ngIf="!this.sidenav.opened"
             (click)="sidenav.toggle()">arrow_forward</button>
     <app-clusterly-inputs (apply)="getDataFromServer($event);"></app-clusterly-inputs>
-    <app-clusters-section (clustersEmitter)="clusters = $event; changSideNavClusters();"
+    <mat-tab-group *ngIf="withSummary === 0"
+                   mat-align-tabs="center"
+                   (selectedTabChange)="tabClicked($event.index)">
+      <mat-tab label="clusterly-edit">
+        <app-clusters-section (clustersEmitter)="clusters = $event; changeSideNavClusters();"
+                              (displayedClustersEmitter)="changeInUiHandler($event);"
+                              [trendsData]="dataFromServer"
+                              [clustersToDisplay]="clustersToShow"
+                              [isSideNavOpened]="this.sidenav.opened"></app-clusters-section>
+      </mat-tab>
+      <mat-tab label="summarized-view">
+        <div id="chart-container">
+          <p class="headline">Summarized View</p>
+          <google-chart [title]="title"
+                        [type]="type"
+                        [data]="data"
+                        [columns]="columnNames"
+                        [options]="options">
+          </google-chart>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
+    <!-- See without Summary view for the external tool. -->
+    <app-clusters-section *ngIf="withSummary === 1"
+                          (clustersEmitter)="clusters = $event; changeSideNavClusters();"
                           (displayedClustersEmitter)="changeInUiHandler($event);"
                           [trendsData]="dataFromServer"
                           [clustersToDisplay]="clustersToShow"></app-clusters-section>
+
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/trendly/src/app/clusters-section/clusters-section.component.css
+++ b/trendly/src/app/clusters-section/clusters-section.component.css
@@ -11,7 +11,7 @@
   border-radius: 5px;
   padding: 5px;
   position: absolute;
-  font-size: 2.7vh;
+  font-size: 1vw;
   font-family: 'Roboto', sans-serif;
   max-width: 300px;
   word-wrap: break-word;
@@ -19,7 +19,7 @@
 }
 
 .delete-button {
-  top: -60%;
+  top: -65%;
   left: 140px;
 }
 
@@ -72,10 +72,6 @@
   margin-right: 22px;
 }
 
-.custom-tooltip {
-  font-size: 25px;
-}
-
 .clusters-titles {
   font-family: 'Roboto', sans-serif;
   font-size: 25px;
@@ -119,4 +115,10 @@
 
 .titles-container:hover .titles-btn-container text {
   opacity: 1;
+}
+
+.move-btn-container circle {
+  color: #000;
+  cursor: grab;
+  r: 20;
 }

--- a/trendly/src/app/clusters-section/clusters-section.component.html
+++ b/trendly/src/app/clusters-section/clusters-section.component.html
@@ -1,15 +1,3 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
       rel="stylesheet">
 <div class="clusters-container"></div>
-<button class="icon-button delete-button"
-        matTooltip="Drag bubble here in order to delete it"
-        matTooltipPosition="right"
-        matTooltipClass="custom-tooltip"
-        #tooltip="matTooltip"
-        (click)="tooltip.show()">
-  <mat-icon class="md-48">delete</mat-icon>
-</button>
-<button class="icon-button add-button"
-        (click)="openAddClusterDialog()">
-  <mat-icon class="md-48">add</mat-icon>
-</button>

--- a/trendly/src/app/clusters-section/clusters-section.component.ts
+++ b/trendly/src/app/clusters-section/clusters-section.component.ts
@@ -101,7 +101,7 @@ export class ClustersSectionComponent {
     // New data arrived from the server.
     if (changes['trendsData']) {
       const clustersData: ClusterDataObj =
-          isUndefined(this.trendsData) ? [] : this.trendsData;
+          isUndefined(this.trendsData) ? CLUSTERS_DATA : this.trendsData;
       if (isUndefined(this.svgContainer) || this.svgContainer.empty()) {
         this.svgContainer = this.addSvg(CLUSTERS_CONTAINER);
       } else {
@@ -141,8 +141,10 @@ export class ClustersSectionComponent {
    * in the current clustersToDisplay but not in the previous clusterIdToLoc).
    */
   private hasClusterAdded(): boolean {
-    for (clusterId in this.clustersToDisplay.keys()) {
-      if (!this.clusterIdToLoc.has(clusterId)) return true;
+    for (const clusterId of this.clustersToDisplay.keys()) {
+      if (!this.clusterIdToLoc.has(clusterId)) {
+        return true;
+      }
     }
     return false;
   }
@@ -789,7 +791,6 @@ export class ClustersSectionComponent {
             return this.clusterIdToLoc.get(d.clusterId).yPosition;
           }
         }))
-
         .force(
             'charge',
             d3.forceManyBody().strength(

--- a/trendly/src/app/clusters-section/mock-data.ts
+++ b/trendly/src/app/clusters-section/mock-data.ts
@@ -17,7 +17,7 @@ export const CLUSTERS_DATA = {
       {title: 'This is query 4 from cluster 1 ', value: 80},
       {title: 'This is query 5 from cluster 1 ', value: 100},
     ],
-    additionalQueries: [],
+    additionalQueries: [{title: 'This is query 1 from cluster 1 ', value: 10}],
     relatedClustersIds: [3]
   },
   '1': {
@@ -49,7 +49,7 @@ export const CLUSTERS_DATA = {
     relatedClustersIds: [3]
   },
   '3': {
-    title: 'Cluster 4',
+    title: 'Clusterrrrrrr 4',
     id: 4,
     volume: 100,
     queriesToDisplay: [
@@ -115,7 +115,7 @@ export const CLUSTERS_DATA = {
       {title: 'hi!!!!', value: 90},
       {title: 'hi!!!!', value: 100},
     ],
-    additionalQueries: [],
+    additionalQueries: [{title: 'hi!!!!', value: 40}],
     relatedClustersIds: []
   },
 };

--- a/trendly/src/app/histogram-section/histogram-section.component.spec.ts
+++ b/trendly/src/app/histogram-section/histogram-section.component.spec.ts
@@ -35,9 +35,12 @@ NEW_MOCK_DATA.set(topic1, {
   'lines': [{
     'term': 'elections',
     'points': [
-      {'value': 15, 'date': '2010-01-03'}, {'value': 21, 'date': '2010-01-10'},
-      {'value': 28, 'date': '2010-01-17'}, {'value': 27, 'date': '2010-01-24'},
-      {'value': 20, 'date': '2010-01-31'}, {'value': 0, 'date': '2010-02-07'},
+      {'value': 15, 'date': '2010-01-03'},
+      {'value': 21, 'date': '2010-01-10'},
+      {'value': 28, 'date': '2010-01-17'},
+      {'value': 27, 'date': '2010-01-24'},
+      {'value': 20, 'date': '2010-01-31'},
+      {'value': 0, 'date': '2010-02-07'},
     ]
   }]
 });
@@ -45,36 +48,33 @@ NEW_MOCK_DATA.set(topic2, {
   'lines': [{
     'term': 'corona',
     'points': [
-      {'value': 15, 'date': '2010-01-03'}, {'value': 21, 'date': '2010-01-10'},
-      {'value': 28, 'date': '2010-01-17'}, {'value': 27, 'date': '2010-01-24'},
-      {'value': 20, 'date': '2010-01-31'}, {'value': 0, 'date': '2010-02-07'},
+      {'value': 15, 'date': '2010-01-03'},
+      {'value': 21, 'date': '2010-01-10'},
+      {'value': 28, 'date': '2010-01-17'},
+      {'value': 27, 'date': '2010-01-24'},
+      {'value': 20, 'date': '2010-01-31'},
+      {'value': 0, 'date': '2010-02-07'},
     ]
   }]
 });
 
 const EXPECT_OUTPUT: Array<Array<string|number>> = [
   [
-    '2010-01-03', 15, 'elections', '#4ec3ff', 15, 'a dangerous virus',
-    '#9467e4'
+    '2010-01-03', 15, 'elections', '#4ec3ff', 15, 'a dangerous virus', '#9467e4'
   ],
   [
-    '2010-01-10', 21, 'elections', '#4ec3ff', 21, 'a dangerous virus',
-    '#9467e4'
+    '2010-01-10', 21, 'elections', '#4ec3ff', 21, 'a dangerous virus', '#9467e4'
   ],
   [
     '2010-01-17', 28, 'elections', '#4ec3ff', 28, 'a dangerous virus', '#9467e4'
   ],
   [
-    '2010-01-24', 27, 'elections', '#4ec3ff', 27, 'a dangerous virus',
-    '#9467e4'
+    '2010-01-24', 27, 'elections', '#4ec3ff', 27, 'a dangerous virus', '#9467e4'
   ],
   [
-    '2010-01-31', 20, 'elections', '#4ec3ff', 20, 'a dangerous virus',
-    '#9467e4'
+    '2010-01-31', 20, 'elections', '#4ec3ff', 20, 'a dangerous virus', '#9467e4'
   ],
-  [
-    '2010-02-07', 0, 'elections', '#4ec3ff', 0, 'a dangerous virus', '#9467e4'
-  ]
+  ['2010-02-07', 0, 'elections', '#4ec3ff', 0, 'a dangerous virus', '#9467e4']
 ];
 
 describe('HistogramSectionComponent', () => {
@@ -118,7 +118,7 @@ describe('HistogramSectionComponent', () => {
   });
 
   it('test output of the component given the mock data', () => {
-    (component as any).mapTrendsData = NEW_MOCK_DATA;
+    (component as any).trendsData = NEW_MOCK_DATA;
     component.convertDataToChartsFormat();
     expect(component.data).toEqual(EXPECT_OUTPUT);
   });

--- a/trendly/src/app/histogramy-component/histogramy-component.component.ts
+++ b/trendly/src/app/histogramy-component/histogramy-component.component.ts
@@ -87,7 +87,7 @@ export class HistogramyComponentComponent {
    */
   private getDefaultDates(): string[] {
     let end: Date = new Date();
-    let month: string = '' + end.getMonth();
+    let month: string = '' + end.getMonth() + 1;
     month = month.length === 1 ? '0' + month : month;
     let yearEnd = '' + end.getFullYear();
     let yearStart = '' + (end.getFullYear() - 1)

--- a/trendly/src/app/merge-dialog/merge-dialog.component.css
+++ b/trendly/src/app/merge-dialog/merge-dialog.component.css
@@ -1,0 +1,50 @@
+.apply-button {
+  background-color: rgb(57, 99, 161);
+  height: 50px;
+  padding: 10px 20px 10px;
+  font-family: "Roboto";
+  font-size: 25px;
+  color: #fff;
+  text-align: center;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  vertical-align: middle;
+}
+
+.btn {
+  display: flex;
+  justify-content: center;
+  padding-right: 15px;
+}
+
+.no-button {
+  background-color: #fff;
+  height: 50px;
+  padding: 10px 20px 10px;
+  font-family: "Roboto";
+  font-size: 25px;
+  color: rgb(57, 99, 161);
+  text-align: center;
+  font-weight: 500;
+  border: 2px solid rgb(57, 99, 161);
+  border-radius: 6px;
+  vertical-align: middle;
+}
+
+.btn-row {
+  margin: 0 auto;
+  padding: 10px 10px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+::ng-deep .mat-dialog-content {
+  font-size: 20px;
+}
+
+::ng-deep #mat-dialog-title-0 {
+  font-size: 25px;
+}

--- a/trendly/src/app/merge-dialog/merge-dialog.component.html
+++ b/trendly/src/app/merge-dialog/merge-dialog.component.html
@@ -1,0 +1,15 @@
+<h1 mat-dialog-title>Merge Confirmation</h1>
+<div mat-dialog-content>
+  Are you sure you want to merge cluster {{data.srcCluster.title}} into cluster
+  {{data.destCluster.title}}?
+  <div class="btn-row">
+    <div class="btn">
+      <button class="apply-button"
+              (click)="data.clusterly.mergeClusters(data.srcCluster, data.destCluster)">Yes</button>
+    </div>
+    <div class="btn">
+      <button class="no-button"
+              (click)="data.clusterly.mergeDialog.closeAll()">No</button>
+    </div>
+  </div>
+</div>

--- a/trendly/src/app/merge-dialog/merge-dialog.component.spec.ts
+++ b/trendly/src/app/merge-dialog/merge-dialog.component.spec.ts
@@ -1,0 +1,74 @@
+import {OverlayContainer} from '@angular/cdk/overlay';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogModule} from '@angular/material/dialog';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {Cluster} from '../models/cluster-model';
+import {MergeDialogComponent, MergeDialogData} from './merge-dialog.component';
+
+const SRC_CLUSTER =
+    new Cluster('src cluster', 1, 100, [{title: '', value: 1}], [], []);
+const DST_CLUSTER =
+    new Cluster('destination cluster', 1, 100, [{title: '', value: 1}], [], []);
+
+const DATA: MergeDialogData = {
+  srcCluster: SRC_CLUSTER,
+  destCluster: DST_CLUSTER,
+  clusterly: null
+};
+
+const CONFIG = {
+  data: DATA
+};
+const DIALOG_TITLE = 'Merge Confirmation';
+const DIALOG_CONTENT =
+    ' Are you sure you want to merge cluster src cluster into cluster destination cluster? YesNo';
+
+describe('MergeDialogComponent', () => {
+  let component: MergeDialogComponent;
+  let dialog: MatDialog;
+  let fixture: ComponentFixture<MergeDialogComponent>;
+  let overlayContainerElement: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed
+        .configureTestingModule({
+          declarations: [MergeDialogComponent],
+          imports: [MatDialogModule, BrowserAnimationsModule],
+          providers: [
+            {provide: MAT_DIALOG_DATA, useValue: DATA}, {
+              provide: OverlayContainer,
+              useFactory: () => {
+                overlayContainerElement = document.createElement('div');
+                return {getContainerElement: () => overlayContainerElement};
+              }
+            }
+          ]
+        })
+        .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MergeDialogComponent);
+    dialog = TestBed.get(MatDialog);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should create merge dialog\'s title correctly', () => {
+    dialog.open(MergeDialogComponent, CONFIG);
+    fixture.detectChanges();
+    const h1 = overlayContainerElement.querySelector('.mat-dialog-title');
+    expect(h1.textContent).toBe(DIALOG_TITLE);
+  });
+
+  it('should create merge dialog\'s content correctly', () => {
+    dialog.open(MergeDialogComponent, CONFIG);
+    fixture.detectChanges();
+    const h1 = overlayContainerElement.querySelector('.mat-dialog-content');
+    expect(h1.textContent).toBe(DIALOG_CONTENT);
+  });
+});

--- a/trendly/src/app/merge-dialog/merge-dialog.component.ts
+++ b/trendly/src/app/merge-dialog/merge-dialog.component.ts
@@ -1,0 +1,25 @@
+import {Component, OnInit} from '@angular/core';
+import {Inject} from '@angular/core';
+import {MAT_DIALOG_DATA} from '@angular/material/dialog';
+
+import {ClustersSectionComponent} from '../clusters-section/clusters-section.component';
+import {Cluster} from '../models/cluster-model';
+
+export interface MergeDialogData {
+  srcCluster: Cluster;
+  destCluster: Cluster;
+  clusterly: ClustersSectionComponent;
+}
+
+/**
+ * Merge confirmation dialog. (Asks the user if he's sure he wans to merge the
+ * cluster they dragged into the other cluster and acts based on his response).
+ */
+@Component({
+  selector: 'app-merge-dialog',
+  templateUrl: './merge-dialog.component.html',
+  styleUrls: ['./merge-dialog.component.css']
+})
+export class MergeDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: MergeDialogData) {}
+}

--- a/trendly/src/app/models/cluster-model.ts
+++ b/trendly/src/app/models/cluster-model.ts
@@ -9,7 +9,8 @@ import {Bubble} from './bubble-model'
 
 export class Cluster {
   readonly bubbles: Set<Bubble>;
-  readonly additionalBubbles: Bubble[];
+  readonly additionalBubbles: Set<Bubble>;
+  isDragged: number = 0;
 
   constructor(
       readonly title: string, readonly id: number, public volume: number,
@@ -17,19 +18,33 @@ export class Cluster {
       readonly relatedClustersIds: number[]) {
     this.bubbles = new Set<Bubble>(queriesToDisplay.map(
         query => new Bubble(query.title, query.value, id)));
-    this.additionalBubbles = additionalQueries.map(
-        query => new Bubble(query.title, query.value, id));
+    this.additionalBubbles = new Set<Bubble>(additionalQueries.map(
+        query => new Bubble(query.title, query.value, id)));
   }
 
   /**
    * Removes the given bubble from this.bubbles and adds it
    * to anotherCluster.bubbles.
    */
-  moveBubble(bubble: Bubble, anotherCluster: Cluster): void {
+  moveBubble(
+      bubble: Bubble, anotherCluster: Cluster,
+      displayed: boolean = true): void {
     bubble.clusterId = anotherCluster.id;
     this.volume -= bubble.volume;
     anotherCluster.volume += bubble.volume;
-    this.bubbles.delete(bubble);
-    anotherCluster.bubbles.add(bubble);
+    displayed ? this.bubbles.delete(bubble) :
+                this.additionalBubbles.delete(bubble);
+    displayed ? anotherCluster.bubbles.add(bubble) :
+                anotherCluster.additionalBubbles.add(bubble);
+  }
+
+  /**
+   * Move each bubble from this.bubbles to anotherCluster.bubbles, and each
+   * bubble from this.additionalBubbles to anotherCluster.additionalBubbles.
+   */
+  moveAllBubbles(anotherCluster: Cluster): void {
+    this.bubbles.forEach((bubble) => this.moveBubble(bubble, anotherCluster));
+    this.additionalBubbles.forEach(
+        (bubble) => this.moveBubble(bubble, anotherCluster, false))
   }
 }

--- a/trendly/src/app/queries-dialog/queries-dialog.component.css
+++ b/trendly/src/app/queries-dialog/queries-dialog.component.css
@@ -12,6 +12,18 @@ table {
   min-width: 300px;
 }
 
+.volume,
+.visibility,
+::ng-deep mat-header-cell:nth-child(3),
+::ng-deep mat-header-cell:nth-child(4) {
+  min-width: 100px;
+}
+
+.select,
+::ng-deep mat-header-cell:nth-child(1) {
+  min-width: 50px;
+}
+
 ::ng-deep .mat-header-cell {
   font-size: 18px;
 }
@@ -47,4 +59,8 @@ table {
 
 ::ng-deep mat-form-field {
   padding-left: 20px;
+}
+
+::ng-deep .icon {
+  font-size: 25px;
 }

--- a/trendly/src/app/queries-dialog/queries-dialog.component.html
+++ b/trendly/src/app/queries-dialog/queries-dialog.component.html
@@ -10,7 +10,8 @@
                       [indeterminate]="selectedQueries.hasValue() && !isAllSelected()">
         </mat-checkbox>
       </mat-header-cell>
-      <mat-cell *matCellDef="let row">
+      <mat-cell class="select"
+                *matCellDef="let row">
         <mat-checkbox (click)="$event.stopPropagation()"
                       (change)="$event ? selectedQueries.toggle(row) : null"
                       [checked]="selectedQueries.isSelected(row)">
@@ -20,17 +21,35 @@
     <!-- Query Column -->
     <ng-container matColumnDef="query">
       <mat-header-cell *matHeaderCellDef> Query </mat-header-cell>
-      <mat-cell class= "query" *matCellDef="let bubble"> {{bubble.query}} </mat-cell>
+      <mat-cell class="query"
+                *matCellDef="let bubble"> {{bubble.query}} </mat-cell>
     </ng-container>
-    <!-- Name Column -->
+    <!-- Volume Column -->
     <ng-container matColumnDef="volume">
       <mat-header-cell *matHeaderCellDef> Volume </mat-header-cell>
-      <mat-cell class= "volume" *matCellDef="let bubble">  {{bubble.volume}} </mat-cell>
+      <mat-cell class="volume"
+                *matCellDef="let bubble"> {{bubble.volume}} </mat-cell>
+    </ng-container>
+    <!-- Visibility Column -->
+    <ng-container matColumnDef="visibility">
+      <mat-header-cell *matHeaderCellDef> Visibility </mat-header-cell>
+      <mat-cell class="visibility"
+                *matCellDef="let bubble">
+        <button mat-icon-button
+                *ngIf="data.currentCluster.bubbles.has(bubble)"
+                (click)="data.clusterly.makeQueryInvisible(bubble, data.currentCluster)">
+          <mat-icon class="icon">visibility</mat-icon>
+        </button>
+        <button mat-icon-button
+                *ngIf="data.currentCluster.additionalBubbles.has(bubble)"
+                (click)="data.clusterly.makeQueryVisible(bubble, data.currentCluster)">
+          <mat-icon class="icon">visibility_off</mat-icon>
+        </button>
+      </mat-cell>
     </ng-container>
     <!-- Columns Headers -->
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: displayedColumns;"
-             (click)="selectedQueries.toggle(row)">
+    <mat-row *matRowDef="let row; columns: displayedColumns;">
     </mat-row>
   </mat-table>
 

--- a/trendly/src/app/queries-dialog/queries-dialog.component.spec.ts
+++ b/trendly/src/app/queries-dialog/queries-dialog.component.spec.ts
@@ -18,7 +18,6 @@ const QUERIES: Bubble[] =
     [new Bubble('query 1', 10, 1), new Bubble('query 2', 15, 2)];
 const DATA: DialogData = {
   currentCluster: CLUSTER1,
-  queries: QUERIES,
   clusters: [CLUSTER1, CLUSTER2]
 };
 const CONFIG = {
@@ -67,26 +66,19 @@ describe('QueriesDialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should create dialog\'s title correctly (with the cluster title)', () => {
-    dialog.open(QueriesDialogComponent, CONFIG);
-    fixture.detectChanges();
-    const h1 = overlayContainerElement.querySelector('.mat-dialog-title');
-    expect(h1.textContent).toBe(DIALOG_TITLE);
-  });
+  it('should create queries\' dialog\'s title correctly (with the cluster title)',
+     () => {
+       dialog.open(QueriesDialogComponent, CONFIG);
+       fixture.detectChanges();
+       const h1 = overlayContainerElement.querySelector('.mat-dialog-title');
+       expect(h1.textContent).toBe(DIALOG_TITLE);
+     });
 
-  it('should create dialog\'s table that match the queries', () => {
-    (component as any).dataSource = new MatTableDataSource<Bubble>(QUERIES);
-    dialog.open(QueriesDialogComponent, CONFIG);
-    fixture.detectChanges();
-    const matList = overlayContainerElement.querySelectorAll('mat-cell');
-    expect(matList.item(1).textContent).toBe(FIRST_QUERY_OPTION);
-    expect(matList.item(4).textContent).toBe(SECOND_QUERY_OPTION);
-  });
-
-  it('should create select options thay match the clusters\' titles', () => {
-    dialog.open(QueriesDialogComponent, CONFIG);
-    fixture.detectChanges();
-    const matForm = overlayContainerElement.querySelector('mat-select');
-    expect(matForm.textContent).toBe(CLUSTER1.title + CLUSTER2.title);
-  });
+  it('should create queries\' select options thay match the clusters\' titles',
+     () => {
+       dialog.open(QueriesDialogComponent, CONFIG);
+       fixture.detectChanges();
+       const matForm = overlayContainerElement.querySelector('mat-select');
+       expect(matForm.textContent).toBe(CLUSTER1.title + CLUSTER2.title);
+     });
 });

--- a/trendly/src/app/queries-dialog/queries-dialog.component.ts
+++ b/trendly/src/app/queries-dialog/queries-dialog.component.ts
@@ -5,17 +5,17 @@ import {MAT_DIALOG_DATA} from '@angular/material/dialog';
 import {MatTableDataSource} from '@angular/material/table';
 
 import {ClusterlyComponent} from '../clusterly/clusterly.component';
+import {ClustersSectionComponent} from '../clusters-section/clusters-section.component';
 import {Bubble} from '../models/bubble-model';
 import {Cluster} from '../models/cluster-model';
 
 export interface DialogData {
-  clusterly?: ClusterlyComponent;
+  clusterly?: ClustersSectionComponent;
   currentCluster: Cluster;
-  queries: Bubble[];
   clusters: Cluster[];
   updateFunc?:
       (newCluster: Cluster, selections: SelectionModel<Bubble>,
-       currCluster: Cluster, clusterly: ClusterlyComponent) => void;
+       currCluster: Cluster, clusterly: ClustersSectionComponent) => void;
 }
 
 /**
@@ -31,13 +31,17 @@ export interface DialogData {
 })
 export class QueriesDialogComponent {
   selectedCluster: Cluster;
-  readonly displayedColumns: string[] = ['select', 'query', 'volume'];
+  readonly displayedColumns: string[] =
+      ['select', 'query', 'volume', 'visibility'];
   readonly dataSource: MatTableDataSource<Bubble>;
   readonly selectedQueries: SelectionModel<Bubble> =
       new SelectionModel<Bubble>(true, []);
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {
-    this.dataSource = new MatTableDataSource<Bubble>(data.queries);
+    this.dataSource = new MatTableDataSource<Bubble>(
+        Array.from(data.currentCluster.bubbles)
+            .concat(Array.from(data.currentCluster.additionalBubbles))
+            .sort((bubble1, bubble2) => bubble2.volume - bubble1.volume));
   }
 
   /**

--- a/trendly/src/assets/img/add-white-18dp.svg
+++ b/trendly/src/assets/img/add-white-18dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>

--- a/trendly/src/assets/img/delete-white-18dp.svg
+++ b/trendly/src/assets/img/delete-white-18dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>

--- a/trendly/src/assets/img/open_with-white-18dp.svg
+++ b/trendly/src/assets/img/open_with-white-18dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 9h4V6h3l-5-5-5 5h3v3zm-1 1H6V7l-5 5 5 5v-3h3v-4zm14 2l-5-5v3h-3v4h3v3l5-5zm-9 3h-4v3H7l5 5 5-5h-3v-3z"/></svg>

--- a/trendly/src/assets/img/open_with-white-24dp.svg
+++ b/trendly/src/assets/img/open_with-white-24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="24px" height="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 9h4V6h3l-5-5-5 5h3v3zm-1 1H6V7l-5 5 5 5v-3h3v-4zm14 2l-5-5v3h-3v4h3v3l5-5zm-9 3h-4v3H7l5 5 5-5h-3v-3z"/></svg>

--- a/trendly/src/assets/img/reply_all-white-18dp.svg
+++ b/trendly/src/assets/img/reply_all-white-18dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 8V5l-7 7 7 7v-3l-4-4 4-4zm6 1V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z"/></svg>


### PR DESCRIPTION
* Add tabs for editing + summarized view.
* Add a visibility column in the queries' dialog that controls which query-bubbles are presented on the screen.
* Change the add new cluster button + delete query button to appear only when a bubble is dragged and in a near location.
* Add an option to rearrange the clusters' locations on the screen.
* Add an option to merge two clusters together.
